### PR TITLE
Change laser_scan from GPU to CPU

### DIFF
--- a/dolly_gazebo/models/dolly/model.sdf
+++ b/dolly_gazebo/models/dolly/model.sdf
@@ -38,7 +38,7 @@
           </mesh>
         </geometry>
       </visual>
-      <sensor name="sensor_gpu_ray" type="gpu_ray">
+      <sensor name="sensor_ray" type="ray">
         <pose>0.5 0 0 0 0 0</pose>
         <ray>
           <scan>


### PR DESCRIPTION
Changed gpu_ray to ray in the dolly model, to make laser_scan work on the CPU instead of a GPU.