### PR TITLE
Use env hooks to set environment variables

### DIFF
--- a/dolly_gazebo/CMakeLists.txt
+++ b/dolly_gazebo/CMakeLists.txt
@@ -29,6 +29,7 @@ install(DIRECTORY
   DESTINATION share/${PROJECT_NAME}/
 )
 
-ament_environment_hooks("${CMAKE_CURRENT_SOURCE_DIR}/env-hooks/dolly_gazebo.sh.in")
+ament_environment_hooks("${CMAKE_CURRENT_SOURCE_DIR}/env-hooks/${PROJECT_NAME}.sh.in")
+ament_environment_hooks("${CMAKE_CURRENT_SOURCE_DIR}/env-hooks/${PROJECT_NAME}.dsv.in")
 
 ament_package()

--- a/dolly_gazebo/CMakeLists.txt
+++ b/dolly_gazebo/CMakeLists.txt
@@ -29,4 +29,6 @@ install(DIRECTORY
   DESTINATION share/${PROJECT_NAME}/
 )
 
+ament_environment_hooks("${CMAKE_CURRENT_SOURCE_DIR}/env-hooks/dolly_gazebo.sh.in")
+
 ament_package()

--- a/dolly_gazebo/env-hooks/dolly_gazebo.dsv.in
+++ b/dolly_gazebo/env-hooks/dolly_gazebo.dsv.in
@@ -1,0 +1,2 @@
+prepend-non-duplicate;GAZEBO_MODEL_PATH;share/@PROJECT_NAME@/models
+prepend-non-duplicate;GAZEBO_RESOURCE_PATH;share/@PROJECT_NAME@/worlds

--- a/dolly_gazebo/env-hooks/dolly_gazebo.sh.in
+++ b/dolly_gazebo/env-hooks/dolly_gazebo.sh.in
@@ -1,0 +1,4 @@
+# generated from dolly_gazebo/env-hooks/dolly_gazebo.sh.in
+
+ament_prepend_unique_value GAZEBO_MODEL_PATH "$AMENT_CURRENT_PREFIX/share/dolly_gazebo/models"
+ament_prepend_unique_value GAZEBO_RESOURCE_PATH "$AMENT_CURRENT_PREFIX/share/dolly_gazebo/worlds"

--- a/dolly_gazebo/env-hooks/dolly_gazebo.sh.in
+++ b/dolly_gazebo/env-hooks/dolly_gazebo.sh.in
@@ -1,4 +1,4 @@
 # generated from dolly_gazebo/env-hooks/dolly_gazebo.sh.in
 
-ament_prepend_unique_value GAZEBO_MODEL_PATH "$AMENT_CURRENT_PREFIX/share/dolly_gazebo/models"
-ament_prepend_unique_value GAZEBO_RESOURCE_PATH "$AMENT_CURRENT_PREFIX/share/dolly_gazebo/worlds"
+ament_prepend_unique_value GAZEBO_MODEL_PATH "$AMENT_CURRENT_PREFIX/share/@PROJECT_NAME@/models"
+ament_prepend_unique_value GAZEBO_RESOURCE_PATH "$AMENT_CURRENT_PREFIX/share/@PROJECT_NAME@/worlds"

--- a/dolly_gazebo/package.xml
+++ b/dolly_gazebo/package.xml
@@ -20,8 +20,6 @@
 
   <export>
     <build_type>ament_cmake</build_type>
-    <gazebo_ros gazebo_model_path="${prefix}/models"/>
-    <gazebo_ros gazebo_media_path="${prefix}/worlds"/>
   </export>
 </package>
 


### PR DESCRIPTION
Using env hooks is a bit more verbose than using `<export>` but it's more general and easier to debug.

This way, when you source your workspace, i.e.

`. install/setup.bash`

You can immediately check the environment variables even before running, i.e.

`env | grep GAZEBO_MODEL_PATH`