### PR TITLE
Foxy support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ sudo: required
 
 env:
   matrix:
-    - DOCKER_IMAGE=ubuntu:18.04
+    - DOCKER_IMAGE=ubuntu:20.04
 
 services:
   - docker

--- a/.travis/build
+++ b/.travis/build
@@ -1,39 +1,35 @@
 #!/bin/bash
 set -ev
 
-# Configuration.
+# Configuration
 export COLCON_WS=~/ws
 export COLCON_WS_SRC=${COLCON_WS}/src
 export DEBIAN_FRONTEND=noninteractive
 
-# Dependencies.
-echo "deb [trusted=yes] http://packages.osrfoundation.org/gazebo/ubuntu-stable bionic main" > /etc/apt/sources.list.d/gazebo-stable.list
-echo "deb [trusted=yes] http://packages.ros.org/ros2/ubuntu bionic main" > /etc/apt/sources.list.d/ros2-latest.list
+# Install system dependencies
 apt-get update -qq
 apt-get install -qq -y \
-  libgazebo9-dev \
-  ignition-citadel \
-  python3-colcon-common-extensions \
-  python-rosdep \
+  curl \
   git
+  gnupg2 \
+  lsb-release
+curl -s https://raw.githubusercontent.com/ros/rosdistro/master/ros.asc | sudo apt-key add -
 
-# Get ros_ign
-mkdir -p $COLCON_WS_SRC
-cd $COLCON_WS_SRC
-git clone https://github.com/ignitionrobotics/ros_ign -b dashing
+echo "deb [arch=$(dpkg --print-architecture)] http://packages.ros.org/ros2/ubuntu $(lsb_release -cs) main" > /etc/apt/sources.list.d/ros2-latest.list
 
-# Install dependencies
+apt-get update -qq
+apt-get install -qq -y \
+  python3-colcon-common-extensions \
+  python-rosdep
+
+# Install ROS, Gazebo and Ignition
 cd $COLCON_WS
 rosdep init
 rosdep update
-rosdep install --from-paths src -i -y --rosdistro eloquent \
-  --skip-keys=ignition-math6 \
-  --skip-keys=ignition-msgs5 \
-  --skip-keys=ignition-transport8 \
-  --skip-keys=ignition-gazebo3
+rosdep install --from-paths src -i -y --rosdistro foxy
 
 # Build
-source /opt/ros/eloquent/setup.bash
+source /opt/ros/foxy/setup.bash
 ln -s /code $COLCON_WS_SRC
 cd $COLCON_WS
 colcon build

--- a/.travis/build
+++ b/.travis/build
@@ -13,7 +13,7 @@ apt-get install -qq -y \
   git \
   gnupg2 \
   lsb-release
-curl -s https://raw.githubusercontent.com/ros/rosdistro/master/ros.asc | sudo apt-key add -
+curl -s https://raw.githubusercontent.com/ros/rosdistro/master/ros.asc | apt-key add -
 
 echo "deb [arch=$(dpkg --print-architecture)] http://packages.ros.org/ros2/ubuntu $(lsb_release -cs) main" > /etc/apt/sources.list.d/ros2-latest.list
 

--- a/.travis/build
+++ b/.travis/build
@@ -24,6 +24,7 @@ apt-get install -qq -y \
 
 # Get ros_ign (TODO: remove once released upstream)
 mkdir -p $COLCON_WS_SRC
+ln -s /code $COLCON_WS_SRC
 cd $COLCON_WS_SRC
 git clone https://github.com/ignitionrobotics/ros_ign -b ros2
 
@@ -31,11 +32,10 @@ git clone https://github.com/ignitionrobotics/ros_ign -b ros2
 cd $COLCON_WS
 rosdep init
 rosdep update
-rosdep install --from-paths src -i -y --rosdistro foxy -v
+rosdep install --from-paths src -i -y --rosdistro foxy
 
 # Build
 source /opt/ros/foxy/setup.bash
-ln -s /code $COLCON_WS_SRC
 cd $COLCON_WS
 colcon build
 

--- a/.travis/build
+++ b/.travis/build
@@ -31,7 +31,7 @@ git clone https://github.com/ignitionrobotics/ros_ign -b ros2
 cd $COLCON_WS
 rosdep init
 rosdep update
-rosdep install --from-paths src -i -y --rosdistro foxy
+rosdep install --from-paths src -i -y --rosdistro foxy -v
 
 # Build
 source /opt/ros/foxy/setup.bash

--- a/.travis/build
+++ b/.travis/build
@@ -22,6 +22,11 @@ apt-get install -qq -y \
   python3-colcon-common-extensions \
   python-rosdep
 
+# Get ros_ign (TODO: remove once released upstream)
+mkdir -p $COLCON_WS_SRC
+cd $COLCON_WS_SRC
+git clone https://github.com/ignitionrobotics/ros_ign -b ros2
+
 # Install ROS, Gazebo and Ignition
 cd $COLCON_WS
 rosdep init

--- a/.travis/build
+++ b/.travis/build
@@ -20,7 +20,7 @@ echo "deb [arch=$(dpkg --print-architecture)] http://packages.ros.org/ros2/ubunt
 apt-get update -qq
 apt-get install -qq -y \
   python3-colcon-common-extensions \
-  python-rosdep
+  python3-rosdep
 
 # Get ros_ign (TODO: remove once released upstream)
 mkdir -p $COLCON_WS_SRC

--- a/.travis/build
+++ b/.travis/build
@@ -10,7 +10,7 @@ export DEBIAN_FRONTEND=noninteractive
 apt-get update -qq
 apt-get install -qq -y \
   curl \
-  git
+  git \
   gnupg2 \
   lsb-release
 curl -s https://raw.githubusercontent.com/ros/rosdistro/master/ros.asc | sudo apt-key add -

--- a/README.md
+++ b/README.md
@@ -11,21 +11,46 @@ Gazebo | Ignition
 -- | --
 ![Dolly Gazebo](images/dolly.gif) | ![Dolly Ignition](images/dolly_ign.gif)
 
+## Versions
+
 Dolly has been tested on:
 
-* ROS 2 version:
-    * ROS Crystal: `crystal` branch
-    * ROS Dashing: `dashing` branch
-    * ROS Eloquent: `master` branch
-* Gazebo version:
-    * Gazebo 9
-* Ignition version:
-    * Citadel
-* Operating system:
-    * Ubuntu Bionic
-    * OSX Sierra (thanks, @Karsten1987 !)
+Branch | ROS | Gazebo-classic | Ignition | OS
+-- | -- | -- | -- | -- | --
+[crystal](https://github.com/chapulina/dolly/tree/crystal) | Crystal | Gazebo 9 | :x: | Ubuntu Bionic
+[dashing](https://github.com/chapulina/dolly/tree/dashing) | Dashing | Gazebo 9 | :x: | Ubuntu Bionic, macOS Sierra
+[eloquent](https://github.com/chapulina/dolly/tree/eloquent) | Eloquent | Gazebo 9, Gazebo 11 | Citadel | Ubuntu Bionic, macOS Sierra
+[foxy](https://github.com/chapulina/dolly/tree/foxy) | Foxy | Gazebo 11 | Citadel | Ubuntu Focal
+
+## Packages
+
+This repository contains the following packages:
+
+* `dolly`: Metapackage which provides all other packages.
+* `dolly_follow`: Provides node with follow logic.
+* `dolly_gazebo`: Robot model, simulation world and launch scripts for Gazebo-classic.
+* `dolly_ignition`: Robot model, simulation world and launch scripts for Ignition.
 
 ## Install
+
+It's encouraged that you build Dolly from source, to learn about how to
+develop your own packages. But in case you just want to give it a quick
+try, there are binaries available too.
+
+### From binaries
+
+Dolly has been released into several ROS distros:
+
+ROS      | Packages
+-------- | --------
+Dashing  | `ros-dashing-dolly`
+         | `ros-dashing-dolly-follow`
+         | `ros-dashing-dolly-gazebo`
+Eloquent | `ros-eloquent-dolly`
+         | `ros-eloquent-dolly-follow`
+         | `ros-eloquent-dolly-gazebo`
+
+### From source
 
 Install instructions for Ubuntu Bionic.
 
@@ -36,15 +61,15 @@ Install instructions for Ubuntu Bionic.
 1. Install the appropriate ROS 2 version as instructed
    [here](https://index.ros.org/doc/ros2/Installation/Linux-Install-Debians/).
 
-1. Clone Dolly:
+1. Clone Dolly, choose the branch according to your ROS distro:
 
         mkdir -p ~/ws/src
         cd ~/ws/src
-        git clone https://github.com/chapulina/dolly
+        git clone https://github.com/chapulina/dolly -b <distro>
 
-1. Ignition only: clone the bridge:
+1. Ignition only, for Eloquent and earlier, clone the bridge:
 
-        git clone https://github.com/ignitionrobotics/ros_ign -b dashing
+        git clone https://github.com/ignitionrobotics/ros_ign -b <distro>
 
 1. Install dependencies:
 
@@ -54,6 +79,8 @@ Install instructions for Ubuntu Bionic.
             --skip-keys=ignition-msgs5 \
             --skip-keys=ignition-transport8 \
             --skip-keys=ignition-gazebo3
+
+    > **Tip**: On Ubuntu Focal, there's no need to skip keys.
 
 1. Build and install:
 
@@ -95,15 +122,6 @@ should be enabled.
 1. Launch Dolly in a station:
 
         ros2 launch dolly_ignition dolly.launch.py
-
-## Packages
-
-This repository contains the following packages:
-
-* `dolly`: Metapackage which provides all other packages.
-* `dolly_follow`: Provides node with follow logic.
-* `dolly_gazebo`: Robot model, simulation world and launch scripts for Gazebo-classic.
-* `dolly_ignition`: Robot model, simulation world and launch scripts for Ignition.
 
 ## Featured
 

--- a/README.md
+++ b/README.md
@@ -13,13 +13,13 @@ Gazebo | Ignition
 
 ## Versions
 
-Dolly has been tested on:
+Dolly is known to work on the following systems.
 
 Branch | ROS | Gazebo-classic | Ignition | OS
--- | -- | -- | -- | -- | --
+-- | -- | -- | -- | --
 [crystal](https://github.com/chapulina/dolly/tree/crystal) | Crystal | Gazebo 9 | :x: | Ubuntu Bionic
 [dashing](https://github.com/chapulina/dolly/tree/dashing) | Dashing | Gazebo 9 | :x: | Ubuntu Bionic, macOS Sierra
-[eloquent](https://github.com/chapulina/dolly/tree/eloquent) | Eloquent | Gazebo 9, Gazebo 11 | Citadel | Ubuntu Bionic, macOS Sierra
+[eloquent](https://github.com/chapulina/dolly/tree/eloquent) | Eloquent | Gazebo 9, Gazebo 11 | Citadel | Ubuntu Bionic
 [foxy](https://github.com/chapulina/dolly/tree/foxy) | Foxy | Gazebo 11 | Citadel | Ubuntu Focal
 
 ## Packages
@@ -126,11 +126,15 @@ should be enabled.
 ## Featured
 
 * QConSF 2018
-    * [Video](https://www.youtube.com/watch?v=Gwbk6Qf_TqY)
-    * [Code](https://github.com/chapulina/simslides/tree/QConSF_Nov2018)
-* [InfoQ: Open Source Robotics: Getting Started with Gazebo and ROS 2](https://www.infoq.com/articles/ros-2-gazebo-tutorial/)
-* [ROS Developers LIVE Class #70: How to Control a Robot with ROS2 (Dashing)](https://www.youtube.com/watch?v=qB4SaP3TZog)
+    * 🎥 [Open Source Robotics: Hands on with Gazebo and ROS 2](https://www.youtube.com/watch?v=Gwbk6Qf_TqY)
+    * ⌨️ [Source code](https://github.com/chapulina/simslides/tree/QConSF_Nov2018)
+* InfoQ
+    * 📰 [Open Source Robotics: Getting Started with Gazebo and ROS 2](https://www.infoq.com/articles/ros-2-gazebo-tutorial/)
+* ROS Developers Live Class
+    * 🎥 [#70 How to Control a Robot with ROS2 (Dashing)](https://www.youtube.com/watch?v=qB4SaP3TZog)
+    * 🎥 [#71 How to visualize sensor data in ROS2](https://www.youtube.com/watch?v=s3fBGSpmER0)
 * ROSConJP 2019
-    * [Video](https://vimeo.com/370247782)
-    * [Code](https://github.com/chapulina/rosconjp_2019)
-
+    * 🎥 [これからのGazebo: ROSのシミュレーションの次世代](https://vimeo.com/370247782)
+    * ⌨️ [Source code](https://github.com/chapulina/rosconjp_2019)
+* ROS Developers Day 2020
+    * 🎥 [Hands-on with Ignition and ROS2](https://youtu.be/nLp4uzN5NMs?t=622)

--- a/dolly_gazebo/launch/dolly.launch.py
+++ b/dolly_gazebo/launch/dolly.launch.py
@@ -41,7 +41,7 @@ def generate_launch_description():
     # Follow node
     follow = Node(
         package='dolly_follow',
-        node_executable='dolly_follow',
+        executable='dolly_follow',
         output='screen',
         remappings=[
             ('cmd_vel', '/dolly/cmd_vel'),
@@ -52,7 +52,7 @@ def generate_launch_description():
     # RViz
     rviz = Node(
         package='rviz2',
-        node_executable='rviz2',
+        executable='rviz2',
         arguments=['-d', os.path.join(pkg_dolly_gazebo, 'rviz', 'dolly_gazebo.rviz')],
         condition=IfCondition(LaunchConfiguration('rviz'))
     )

--- a/dolly_ignition/launch/dolly.launch.py
+++ b/dolly_ignition/launch/dolly.launch.py
@@ -39,7 +39,7 @@ def generate_launch_description():
     )
 
     # Spawn dolly
-    spawn = Node(package='ros_ign_gazebo', node_executable='create',
+    spawn = Node(package='ros_ign_gazebo', executable='create',
                  arguments=[
                     '-name', 'dolly',
                     '-x', '5.0',
@@ -52,7 +52,7 @@ def generate_launch_description():
     # Follow node
     follow = Node(
         package='dolly_follow',
-        node_executable='dolly_follow',
+        executable='dolly_follow',
         output='screen',
         remappings=[
             ('cmd_vel', '/dolly/cmd_vel'),
@@ -63,7 +63,7 @@ def generate_launch_description():
     # Bridge
     bridge = Node(
         package='ros_ign_bridge',
-        node_executable='parameter_bridge',
+        executable='parameter_bridge',
         arguments=['/dolly/cmd_vel@geometry_msgs/msg/Twist@ignition.msgs.Twist',
                    '/dolly/laser_scan@sensor_msgs/msg/LaserScan@ignition.msgs.LaserScan',
                    '/dolly/odometry@nav_msgs/msg/Odometry@ignition.msgs.Odometry'],
@@ -73,7 +73,7 @@ def generate_launch_description():
     # RViz
     rviz = Node(
         package='rviz2',
-        node_executable='rviz2',
+        executable='rviz2',
         arguments=['-d', os.path.join(pkg_dolly_ignition, 'rviz', 'dolly_ignition.rviz')],
         condition=IfCondition(LaunchConfiguration('rviz'))
     )


### PR DESCRIPTION
The `eloquent` branch also works with Foxy, but there are some warnings because of `node_executable`.

Also, this PR updates CI so that we build against upstream Gazebo 11 and Ignition Citadel.