### PR TITLE
More detailed collision for CPU lidar

### DIFF
--- a/dolly_gazebo/models/casual_female/model.sdf
+++ b/dolly_gazebo/models/casual_female/model.sdf
@@ -4,11 +4,11 @@
     <static>true</static>
     <link name="link">
       <collision name="box">
-        <pose>0 0 0.9 0 0 0</pose>
+        <pose>0 0 0.02 0.04 0 0</pose>
         <geometry>
-          <box>
-            <size>0.76 0.33 1.77</size>
-          </box>
+          <mesh>
+            <uri>model://casual_female/meshes/casual_female.dae</uri>
+          </mesh>
         </geometry>
       </collision>
       <visual name="visual">


### PR DESCRIPTION
The woman's geometry was originally a box for performance reasons. But since Dolly's lidar was changed to CPU rays on #10, let's use the detailed mesh so that the sensor looks at something more interesting.