### PR TITLE
Make ros_ign_gazebo more than exec_depend

### DIFF
--- a/dolly_ignition/package.xml
+++ b/dolly_ignition/package.xml
@@ -11,9 +11,10 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 
+  <depend>ros_ign_gazebo</depend>
+
   <exec_depend>dolly_follow</exec_depend>
   <exec_depend>ros_ign_bridge</exec_depend>
-  <exec_depend>ros_ign_gazebo</exec_depend>
   <exec_depend>ros2launch</exec_depend>
   <exec_depend>rviz2</exec_depend>
 


### PR DESCRIPTION
Thank you for catching this, @ruffsl, I think this should fix the dependency issue when creating debs.

Resolves #25 