### PR TITLE
Small improvements to CI

### DIFF
--- a/.github/workflows/build-and-test.sh
+++ b/.github/workflows/build-and-test.sh
@@ -15,15 +15,6 @@ export MESA_GL_VERSION_OVERRIDE=3.3
 apt update -qq
 apt install -qq -y lsb-release wget curl build-essential
 
-# Fortres isn't on packages.ros.org yet, so we get it from packages.osrfoundation.org
-# Once it's on packages.ros.org, it can be installed with rosdep below
-if [ "$IGNITION_VERSION" == "fortress" ]; then
-  echo "deb http://packages.osrfoundation.org/gazebo/ubuntu-stable `lsb_release -cs` main" > /etc/apt/sources.list.d/gazebo-stable.list
-  wget https://packages.osrfoundation.org/gazebo.key -O - | apt-key add -
-
-  IGN_DEPS="ignition-fortress"
-fi
-
 # Tools and dependencies
 echo "deb http://packages.ros.org/ros2/ubuntu `lsb_release -cs` main" > /etc/apt/sources.list.d/ros2-latest.list
 curl -s https://raw.githubusercontent.com/ros/rosdistro/master/ros.asc | apt-key add -
@@ -45,7 +36,7 @@ rosdep install --from-paths $COLCON_WS_SRC -i -y -r --rosdistro $ROS_DISTRO
 # Build
 source /opt/ros/$ROS_DISTRO/setup.bash
 cd $COLCON_WS
-colcon build --event-handlers console_direct+
+colcon build --event-handlers console_direct+ --packages-up-to dolly
 
 # Test
 colcon test --event-handlers console_direct+ --packages-select-regex dolly


### PR DESCRIPTION
* Fortress is now on http://packages.ros.org
* Since we're compiling `ros_ign`, only compile the packages needed by dolly