### PR TITLE
Add Humble CI

### DIFF
--- a/.github/workflows/build-and-test.sh
+++ b/.github/workflows/build-and-test.sh
@@ -16,7 +16,7 @@ apt update -qq
 apt install -qq -y lsb-release wget curl build-essential
 
 # Tools and dependencies
-echo "deb http://packages.ros.org/ros2/ubuntu `lsb_release -cs` main" > /etc/apt/sources.list.d/ros2-latest.list
+echo "deb http://packages.ros.org/ros2-testing/ubuntu `lsb_release -cs` main" > /etc/apt/sources.list.d/ros2-testing.list
 curl -s https://raw.githubusercontent.com/ros/rosdistro/master/ros.asc | apt-key add -
 apt-get update -qq
 apt-get install -y $IGN_DEPS \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,10 @@ jobs:
     strategy:
       matrix:
         include:
-          - docker-image: "ubuntu:20.04"
+          - docker-image: "ubuntu:22.04"
+            ignition-version: "fortress"
+            ros-distro: "humble"
+          - docker-image: "ubuntu:22.04"
             ignition-version: "fortress"
             ros-distro: "rolling"
     container:

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Branch | ROS | Gazebo-classic | Ignition | OS
 [dashing](https://github.com/chapulina/dolly/tree/dashing) | Dashing | Gazebo 9 | :x: | Ubuntu Bionic, macOS Sierra
 [eloquent](https://github.com/chapulina/dolly/tree/eloquent) | Eloquent | Gazebo 9, Gazebo 11 | Citadel | Ubuntu Bionic
 [foxy](https://github.com/chapulina/dolly/tree/foxy) | Foxy | Gazebo 11 | Citadel | Ubuntu Focal
-[galactic](https://github.com/chapulina/dolly/tree/galactic) | Galactic, Rolling | Gazebo 11 | Edifice, Fortress | Ubuntu Focal
+[galactic](https://github.com/chapulina/dolly/tree/galactic) | Galactic, Humble, Rolling | Gazebo 11 | Edifice, Fortress | Ubuntu Focal, Jammy
 
 ## Packages
 
@@ -61,7 +61,7 @@ supported ones:
 
 ### From source
 
-Install instructions for Ubuntu Bionic.
+Install instructions for Ubuntu Focal or higher.
 
 1. Install at least one simulator,
    [Gazebo](http://gazebosim.org/tutorials?cat=install) or


### PR DESCRIPTION
The `galactic` branch supports versions from Galactic and higher, as described on the changelog. CI only runs for Fortress though.

This PR:

* Moves Rolling CI to Jammy (22.04)
* Adds the use of the `testing` repo, which is good practice in CI so we get packages that have been bloomed, but not synced yet
* Also test the Fortress + Humble combination

The action is currently failing with `Failed to detect successful installation of [ros-rolling-gazebo-ros-pkgs]` because of 

* https://github.com/ros-simulation/gazebo_ros_pkgs/issues/1359