### PR TITLE
[kilted] Update deprecated call to ament_target_dependencies

### DIFF
--- a/dolly_follow/CMakeLists.txt
+++ b/dolly_follow/CMakeLists.txt
@@ -19,10 +19,11 @@ set(target "dolly_follow")
 
 add_executable(${target} src/${target}.cpp)
 
-ament_target_dependencies(${target}
+target_link_libraries(${target} PUBLIC
   "rclcpp"
   "geometry_msgs"
-  "sensor_msgs")
+  "sensor_msgs"
+)
 
 if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)

--- a/dolly_follow/CMakeLists.txt
+++ b/dolly_follow/CMakeLists.txt
@@ -20,9 +20,10 @@ set(target "dolly_follow")
 add_executable(${target} src/${target}.cpp)
 
 target_link_libraries(${target} PUBLIC
-  "rclcpp"
-  "geometry_msgs"
-  "sensor_msgs"
+  ${geometry_msgs_TARGETS}
+  ${sensor_msgs_TARGETS}
+  rclcpp::rclcpp
+  sensor_msgs::sensor_msgs_library
 )
 
 if(BUILD_TESTING)


### PR DESCRIPTION
As of the ROS 2 Kilted release [`ament_target_dependencies` is deprecated.](https://docs.ros.org/en/kilted/Releases/Release-Kilted-Kaiju.html#ament-target-dependencies-is-deprecated)

This PR updates the syntax. Caution should be used to ensure that the target branch is not used for other ROS 2 distros.

Note: This PR was generated by a bot script, but using the simple pattern matching of the [`ros_glint`](https://github.com/MetroRobots/ros_glint) library. No LLMs were used.
